### PR TITLE
handle empty host header

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -87,6 +87,10 @@ Server.prototype.createServer = function(port, address, debug){
           xfwd: true
         });
       }
+    }).catch(function(error){
+      console.log(error);
+      res.write('Error: ' + error);
+      res.end();
     });
   }
   
@@ -107,9 +111,10 @@ Server.prototype.createServer = function(port, address, debug){
 Server.prototype.getTarget = function(ip, host, port){
   var server = this;
   //Ensure that a port is given, port 80 and 443 are not always
-  var key = host.replace(/:.*/, '') + ':' + port;
+  var key = host && host.replace(/:.*/, '') + ':' + port;
   
   return Q.fcall(function(){
+    if (!key) { throw "No host header"; }
     server.setActivity(server.config.etcd.directory + '/active-hosts/' + key);
     return server.getRecord(key);
   }).then(function(record){

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,19 +78,12 @@ Server.prototype.createServer = function(port, address, debug){
   function handleWSRequest(req, socket, head){
     //get target and then proxy request
     server.getTarget(req.socket.remoteAddress, req.headers.host, port).then(function(target){
-      if(target.redirect){
-        res.writeHead(302, { 'Location': target.redirect });
-        res.end();
-      } else {
-        server.proxy.ws(req, socket, head, {
-          target: 'ws://' + target.url,
-          xfwd: true
-        });
-      }
+      server.proxy.ws(req, socket, head, {
+        target: 'ws://' + target.url,
+        xfwd: true
+      });
     }).catch(function(error){
       console.log(error);
-      res.write('Error: ' + error);
-      res.end();
     });
   }
   


### PR DESCRIPTION
Any reason not to catch errors on web socket requests like we do on http?
